### PR TITLE
Add loop toggle to audio player

### DIFF
--- a/src/pages/songs/[lang]/[id].astro
+++ b/src/pages/songs/[lang]/[id].astro
@@ -443,6 +443,11 @@ if (lang === 'en') {
       <option value="1.5">1.5x</option>
       <option value="2">2x</option>
     </select>
+    <button id="loop-btn" aria-label="Toggle loop" class="ml-3 w-6 h-6 flex items-center justify-center text-gray-600 dark:text-gray-300 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+      </svg>
+    </button>
   </div>
 </div>
           

--- a/src/scripts/songs.js
+++ b/src/scripts/songs.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const progressBar = document.getElementById('progress-bar');
     const volumeLevel = document.getElementById('volume-level');
     const playbackSpeed = document.getElementById('playback-speed');
+    const loopBtn = document.getElementById('loop-btn');
     const playIcon = document.querySelector('.play-icon');
     const pauseIcon = document.querySelector('.pause-icon');
     const loadingIcon = document.querySelector('.loading-icon');
@@ -519,6 +520,27 @@ document.addEventListener('DOMContentLoaded', function() {
           console.error('Error changing playback speed:', err);
         }
       });
+    }
+
+    // Loop toggle
+    function updateLoopButton() {
+      if (!loopBtn) return;
+      if (audioElement.loop) {
+        loopBtn.classList.remove('text-gray-600', 'dark:text-gray-300');
+        loopBtn.classList.add('text-indigo-600', 'dark:text-indigo-400');
+      } else {
+        loopBtn.classList.add('text-gray-600', 'dark:text-gray-300');
+        loopBtn.classList.remove('text-indigo-600', 'dark:text-indigo-400');
+      }
+    }
+
+    if (loopBtn) {
+      loopBtn.addEventListener('click', function(e) {
+        e.preventDefault();
+        audioElement.loop = !audioElement.loop;
+        updateLoopButton();
+      });
+      updateLoopButton();
     }
     
     // AUDIO ELEMENT EVENTS


### PR DESCRIPTION
## Summary
- add Loop button to song page audio controls
- support toggling audio loop state in player script

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68701af609a4832e9eb2d4569c5129fa